### PR TITLE
Clean up formatting of Taxonomy_wf.rst

### DIFF
--- a/Taxonomy_wf.rst
+++ b/Taxonomy_wf.rst
@@ -23,22 +23,28 @@ Preparation Steps
 
 This will only need to be done once.
 
-** 1. Download and extract the necessary files **
+1. Download and extract the necessary files
+...........................................
 
 `SILVA Nr99 132 SSU database
 <https://www.arb-silva.de/fileadmin/silva_databases/release_132/Exports/SILVA_132_SSURef_Nr99_tax_silva_trunc.fasta.gz>`_
 
-`Auxilary file <https://github.com/ctmrbio/Amplicon_workflows/blob/master/contaminating_seqs.tsv>`_
+`Auxilary file <https://raw.githubusercontent.com/ctmrbio/Amplicon_workflows/master/contaminating_seqs.tsv>`_
 
-`Clean-up script <https://github.com/ctmrbio/Amplicon_workflows/blob/master/clean_silva.py>`_
+`Clean-up script <https://raw.githubusercontent.com/ctmrbio/Amplicon_workflows/master/clean_silva.py>`_
 
-** 2. Select only the taxonomy **
+2. Select only the taxonomy
+............................
+
+.. code::
 
   gunzip SILVA_132_SSURef_Nr99_tax_silva_trunc.fasta.gz
+  grep '^>' SILVA_132_SSURef_Nr99_tax_silva_trunc.fasta | sed 's/ /\t/' > SILVA_132_SSURef_Nr99.tax.tsv
   
-  grep '^>' SILVA_132_SSURef_Nr99_tax_silva_trunc.fasta > SILVA_132_SSURef_Nr99.tax.tsv
-  
-** 3. Run the clean-up script **
+3. Run the clean-up script
+..........................
+
+.. code::
 
   python clean_silva.py -i SILVA_132_SSURef_Nr99.tax.tsv -o SILVA_132_SSURef_Nr99.tax.clean.tsv -a contaminating_seqs.tsv
 
@@ -50,29 +56,26 @@ taxonomy based on the `PR2 <https://figshare.com/articles/Protist_Ribosomal_Refe
 database and were extended by `Luisa W. Hugerth <https://scholar.google.com/citations?user=7JXgYtsAAAAJ&hl=en>`_ 
 to its current 16S/SILVA-based format.
 
-
-
-** 1: Mapping OTU to a curated database**
+1: Mapping OTU to a curated database
+....................................
 
 Use vsearch or a similar tool to map your amplicons to the database as fast as Usearch would, but produce a blast-like output.
 
-Example:
+Example::
 
     vsearch --usearch_global centroids.fa -db SILVA_132_SSURef_Nr99_tax_silva_trunc.fasta --blast6out centroids2silva.blast --id 0.9 --maxaccepts 45
 
-** 2. Parse the taxonomy **
+2. Parse the taxonomy
+.....................
 
 The trick here is that we'll parse the same mapping result att diferent levels of similarity and keep the best classification possible for the level of similarity found. The similarity levels presented here work well in our experience, but they're not universal for all clades. Specific research questions might require optimizing them.
 
-The script was originally meant for unmerged reads, therefore the -1 and -2 flags. Just repeat the same input file twice if reads were merged.
+The script was originally meant for unmerged reads, therefore the ``-1`` and ``-2`` flags. Just repeat the same input file twice if reads were merged.
 
-Example:
+Example::
 
     SIMS=(90 95 97 99 100) for sim in ${SIMS[@]}; do
-
         python taxonomy_blast_parser.py -1 centroids2silva.blast -2 centroids2silva.blast -id $sim -tax silva_128_Nr99_no-euk_curated.tsv -l1 350 -l2 350 > parse.${sim}.out
-
     done
-
     python combine_taxonomy.py -i parse.100.out,parse.99.out,parse.97.out,parse.95.out,parse.90.out -n strain,species,genus,class,phylum -d 8,7,6,3,2 > taxonomy.out
 


### PR DESCRIPTION
* Made the steps into proper subheaders. I think it makes things easier to read.
* Changed file links to point directly to raw version for easier download.
* Added ``code`` directives for code, so the long lines get small scroll bars.
* Added extra `sed` command to step `2. Select only the taxonomy`, to introduce the missing tab that otherwise introduces an error when trying to run the clean-up script.